### PR TITLE
Reduce Secret Logging Verbosity

### DIFF
--- a/src/main/java/org/ggt/kafka/config/provider/KafkaEnvConfigProvider.java
+++ b/src/main/java/org/ggt/kafka/config/provider/KafkaEnvConfigProvider.java
@@ -25,6 +25,7 @@ public class KafkaEnvConfigProvider implements ConfigProvider {
   public ConfigData get(String path) {
     LOGGER.debug("get(path) method invoked [path={}] ...", path);
     ConfigData configData = new ConfigData(propertiesProvider.getProperties());
+    LOGGER.debug("returning ConfigData [data={}, ttl={}]", configData.data(), configData.ttl());
 
     return configData;
   }
@@ -33,6 +34,7 @@ public class KafkaEnvConfigProvider implements ConfigProvider {
   public ConfigData get(String path, Set<String> keys) {
     LOGGER.info("get(path, keys) method invoked [path={}, keys={}]", path, keys);
     ConfigData configData = new ConfigData(propertiesProvider.getProperties(keys));
+    LOGGER.debug("returning ConfigData [data={}, ttl={}]", configData.data(), configData.ttl());
 
     return configData;
   }

--- a/src/main/java/org/ggt/kafka/config/provider/KafkaEnvConfigProvider.java
+++ b/src/main/java/org/ggt/kafka/config/provider/KafkaEnvConfigProvider.java
@@ -25,7 +25,6 @@ public class KafkaEnvConfigProvider implements ConfigProvider {
   public ConfigData get(String path) {
     LOGGER.debug("get(path) method invoked [path={}] ...", path);
     ConfigData configData = new ConfigData(propertiesProvider.getProperties());
-    LOGGER.info("returning ConfigData [data={}, ttl={}]", configData.data(), configData.ttl());
 
     return configData;
   }
@@ -34,7 +33,6 @@ public class KafkaEnvConfigProvider implements ConfigProvider {
   public ConfigData get(String path, Set<String> keys) {
     LOGGER.info("get(path, keys) method invoked [path={}, keys={}]", path, keys);
     ConfigData configData = new ConfigData(propertiesProvider.getProperties(keys));
-    LOGGER.info("returning ConfigData [data={}, ttl={}]", configData.data(), configData.ttl());
 
     return configData;
   }


### PR DESCRIPTION
Hi there,

Firstly, thanks for this great Config Provider. This PR sees a minor change to the logging level of one of the logging statements from INFO to DEBUG. We are using this in conjunction with the `confluentinc/cp-kafka-connect` docker container and with an INFO level we are having our secret environment variables written to stdout (something which we want to avoid and this PR allows us to).