### PR TITLE
reference environment variables syntax updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,5 +66,5 @@ You can then reference environment variables from `Kafka connect` connector
 configurations as follows:
 
 ```
-${env:/ENVIRONMENT_VARIABLE_NAME}
+${env:ENVIRONMENT_VARIABLE_NAME}
 ```


### PR DESCRIPTION
When specified as
```
${env:/ENVIRONMENT_VARIABLE_NAME}
```
The env var name is considered as `/ENVIRONMENT_VARIABLE_NAME`, whereas, it should be `ENVIRONMENT_VARIABLE_NAME` only. I faced this issue in my connector extended from `confluentinc/cp-kafka-connect` and hence tried to give it like 
```
${env:ENVIRONMENT_VARIABLE_NAME}
``` 
and it worked then. 